### PR TITLE
Convert AsyncTasks to IntentService

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -236,6 +236,7 @@
         <service android:name="com.prey.activities.LoadContactService" android:exported="false"/>
         <service android:name="com.prey.services.CreateAccountService" android:exported="false"/>
         <service android:name="com.prey.services.CheckPasswordService" android:exported="false"/>
+        <service android:name="com.prey.services.AddDeviceToAccountService" android:exported="false"/>
         
         <!-- Receivers -->
         <receiver android:name="com.prey.receivers.SmsReceiver">

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -231,6 +231,7 @@
         <service android:name="com.prey.beta.services.PreyBetaRunnerService" />
         <service android:name="com.prey.actions.report.ReportService" />
         <service android:name="com.prey.services.AddDeviceToApiKeyBatch" android:exported="false"/>
+        <service android:name="com.prey.services.DetachDeviceService" android:exported="false"/>
         
         <!-- Receivers -->
         <receiver android:name="com.prey.receivers.SmsReceiver">

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -230,6 +230,7 @@
         <service android:name="com.prey.services.PreyDisablePowerOptionsService" />
         <service android:name="com.prey.beta.services.PreyBetaRunnerService" />
         <service android:name="com.prey.actions.report.ReportService" />
+        <service android:name="com.prey.services.AddDeviceToApiKeyBatch" android:exported="false"/>
         
         <!-- Receivers -->
         <receiver android:name="com.prey.receivers.SmsReceiver">

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -233,6 +233,7 @@
         <service android:name="com.prey.services.AddDeviceToApiKeyBatch" android:exported="false"/>
         <service android:name="com.prey.services.DetachDeviceService" android:exported="false"/>
         <service android:name="com.prey.services.RevokedPasswordPhraseService" android:exported="false"/>
+        <service android:name="com.prey.activities.LoadContactService" android:exported="false"/>
         
         <!-- Receivers -->
         <receiver android:name="com.prey.receivers.SmsReceiver">

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -235,6 +235,7 @@
         <service android:name="com.prey.services.RevokedPasswordPhraseService" android:exported="false"/>
         <service android:name="com.prey.activities.LoadContactService" android:exported="false"/>
         <service android:name="com.prey.services.CreateAccountService" android:exported="false"/>
+        <service android:name="com.prey.services.CheckPasswordService" android:exported="false"/>
         
         <!-- Receivers -->
         <receiver android:name="com.prey.receivers.SmsReceiver">

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -234,6 +234,7 @@
         <service android:name="com.prey.services.DetachDeviceService" android:exported="false"/>
         <service android:name="com.prey.services.RevokedPasswordPhraseService" android:exported="false"/>
         <service android:name="com.prey.activities.LoadContactService" android:exported="false"/>
+        <service android:name="com.prey.services.CreateAccountService" android:exported="false"/>
         
         <!-- Receivers -->
         <receiver android:name="com.prey.receivers.SmsReceiver">

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -232,6 +232,7 @@
         <service android:name="com.prey.actions.report.ReportService" />
         <service android:name="com.prey.services.AddDeviceToApiKeyBatch" android:exported="false"/>
         <service android:name="com.prey.services.DetachDeviceService" android:exported="false"/>
+        <service android:name="com.prey.services.RevokedPasswordPhraseService" android:exported="false"/>
         
         <!-- Receivers -->
         <receiver android:name="com.prey.receivers.SmsReceiver">

--- a/src/com/prey/activities/PasswordActivity.java
+++ b/src/com/prey/activities/PasswordActivity.java
@@ -7,27 +7,41 @@
 package com.prey.activities;
 
 import android.app.ProgressDialog;
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.graphics.Typeface;
-import android.net.Uri;
-import android.os.AsyncTask;
 import android.text.method.PasswordTransformationMethod;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Toast;
 
-import com.prey.events.Event;
-import com.prey.events.manager.EventManagerRunner;
-import com.prey.exceptions.PreyException;
-import com.prey.net.PreyWebServices;
-import com.prey.PreyConfig;
 import com.prey.PreyStatus;
 import com.prey.R;
+import com.prey.events.Event;
+import com.prey.events.manager.EventManagerRunner;
+import com.prey.services.CheckPasswordService;
 public class PasswordActivity extends PreyActivity {
-	
+
+	public static final String CHECKPWD_FILTER = "PasswordActivity_receiver";
 	int wrongPasswordIntents = 0;
+	private CheckPasswordReceiver receiver;
+
+	@Override
+	protected void onCreate(android.os.Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		receiver = new CheckPasswordReceiver();
+		registerReceiver(receiver, new IntentFilter(CHECKPWD_FILTER));
+	}
+
+	@Override
+	protected void onDestroy() {
+		super.onDestroy();
+		if (receiver != null)
+			unregisterReceiver(receiver);
+	}
 	
 	protected void bindPasswordControls() {
 		Button checkPasswordOkButton = (Button) findViewById(R.id.password_btn_login);
@@ -43,7 +57,11 @@ public class PasswordActivity extends PreyActivity {
 					if(passwordtyped.length()<6||passwordtyped.length()>32){
 						Toast.makeText(ctx, ctx.getString(R.string.error_password_out_of_range,6,32), Toast.LENGTH_LONG).show();
 					}else{
-						new CheckPassword().execute(passwordtyped);
+						Intent checkPwd = new Intent(PasswordActivity.this, CheckPasswordService.class);
+						receiver.showProgressDialog();
+						String[] params = { passwordtyped };
+						checkPwd.putExtra("params", params);
+						PasswordActivity.this.startService(checkPwd);
 					}
 				}
 
@@ -92,16 +110,14 @@ public class PasswordActivity extends PreyActivity {
 		((TextView) findViewById(R.id.login_h2_text)).setText(h2);*/
 	}
 	
-	protected class CheckPassword extends AsyncTask<String, Void, Void> {
+	protected class CheckPasswordReceiver extends BroadcastReceiver {
 
 		ProgressDialog progressDialog = null;
 		boolean isPasswordOk = false;
-		boolean keepAsking = true;
 		String error = null;
 		
 
-		@Override
-		protected void onPreExecute() {
+		public void showProgressDialog() {
 			try{
 				progressDialog = new ProgressDialog(PasswordActivity.this);
 				progressDialog.setMessage(PasswordActivity.this.getText(R.string.password_checking_dialog).toString());
@@ -114,23 +130,11 @@ public class PasswordActivity extends PreyActivity {
 		}
 
 		@Override
-		protected Void doInBackground(String... password) {
-			try {
-				String email = getPreyConfig().getEmail();
-				isPasswordOk = PreyWebServices.getInstance().checkPassword(PasswordActivity.this, email, password[0]);
-				//if (isPasswordOk)
-					//PreyConfig.getPreyConfig(CheckPasswordActivity.this).setPassword(password[0]);
-
-			} catch (PreyException e) {
-				error = e.getMessage();
-			}
-			return null;
-		}
-
-		@Override
-		protected void onPostExecute(Void unused) {
+		public void onReceive(Context receiverContext, Intent receiverIntent) {
+			error = receiverIntent.getStringExtra("error");
+			isPasswordOk = receiverIntent.getBooleanExtra("isPasswordOk", false);
 			try{
-				if (progressDialog.isShowing()){
+				if (progressDialog != null && progressDialog.isShowing()){
 					progressDialog.dismiss();
 				}
 			}catch(Exception e){
@@ -145,8 +149,8 @@ public class PasswordActivity extends PreyActivity {
 					wrongPasswordIntents++;
 					if (wrongPasswordIntents == 3) {
 						Toast.makeText(PasswordActivity.this, R.string.password_intents_exceed, Toast.LENGTH_LONG).show();
-						setResult(RESULT_CANCELED);
-						finish();
+						PasswordActivity.this.setResult(RESULT_CANCELED);
+						PasswordActivity.this.finish();
 					} else {
 						Toast.makeText(PasswordActivity.this, R.string.password_wrong, Toast.LENGTH_SHORT).show();
 					}

--- a/src/com/prey/contacts/ContactAccessor.java
+++ b/src/com/prey/contacts/ContactAccessor.java
@@ -36,7 +36,7 @@ import com.prey.PreyLogger;
  * social status updates (see {@link android.provider.ContactsContract.StatusUpdates}).
  * </ul>
  */
-public class ContactAccessor {
+public class ContactAccessor implements java.io.Serializable {
 
     public Intent getPickContactIntent() {
         return new Intent(Intent.ACTION_PICK, Contacts.CONTENT_URI);

--- a/src/com/prey/contacts/ContactInfo.java
+++ b/src/com/prey/contacts/ContactInfo.java
@@ -11,7 +11,7 @@ import android.graphics.Bitmap;
 /**
  * A model object containing contact data.
  */
-public class ContactInfo {
+public class ContactInfo implements java.io.Serializable {
 
     private String mDisplayName;
     private String mPhoneNumber;

--- a/src/com/prey/services/AddDeviceToAccountService.java
+++ b/src/com/prey/services/AddDeviceToAccountService.java
@@ -1,0 +1,48 @@
+package com.prey.services;
+
+import android.app.IntentService;
+import android.content.Intent;
+
+import com.prey.PreyAccountData;
+import com.prey.PreyConfig;
+import com.prey.activities.AddDeviceToAccountActivity;
+import com.prey.exceptions.NoMoreDevicesAllowedException;
+import com.prey.exceptions.PreyException;
+import com.prey.net.PreyWebServices;
+
+public class AddDeviceToAccountService extends IntentService {
+	String error;
+	boolean noMoreDeviceError;
+
+	public AddDeviceToAccountService(String name) {
+		super(name);
+	}
+
+	public void onHandleIntent(Intent intent) {
+		String[] data = intent.getStringArrayExtra("params");
+		try {
+			noMoreDeviceError = false;
+			error = null;
+			PreyAccountData accountData = PreyWebServices.getInstance()
+					.registerNewDeviceToAccount(this, data[0], data[1], data[2]);
+			getPreyConfig().saveAccount(accountData);
+		} catch (PreyException e) {
+			error = e.getMessage();
+			try {
+				NoMoreDevicesAllowedException noMoreDevices = (NoMoreDevicesAllowedException) e;
+				noMoreDeviceError = true;
+			} catch (ClassCastException e1) {
+				noMoreDeviceError = false;
+			}
+		}
+		Intent resultIntent = new Intent(AddDeviceToAccountActivity.ADDDEVICE_FILTER);
+		resultIntent.putExtra("error", error);
+		resultIntent.putExtra("noMoreDeviceError", noMoreDeviceError);
+		sendBroadcast(resultIntent);
+		return;
+	}
+
+	private PreyConfig getPreyConfig() {
+		return PreyConfig.getPreyConfig(this);
+	}
+}

--- a/src/com/prey/services/AddDeviceToApiKeyBatch.java
+++ b/src/com/prey/services/AddDeviceToApiKeyBatch.java
@@ -1,0 +1,39 @@
+package com.prey.services;
+
+import android.app.IntentService;
+import android.content.Intent;
+
+import com.prey.PreyAccountData;
+import com.prey.PreyConfig;
+import com.prey.activities.WelcomeBatchActivity;
+import com.prey.exceptions.PreyException;
+import com.prey.net.PreyWebServices;
+
+public class AddDeviceToApiKeyBatch extends IntentService {
+	private String error;
+
+	public AddDeviceToApiKeyBatch(String name) {
+		super(name);
+	}
+
+	public void onHandleIntent(Intent intent) {
+		String[] data = intent.getStringArrayExtra("params");
+		try {
+			error = null;
+			PreyAccountData accountData = PreyWebServices.getInstance()
+					.registerNewDeviceWithApiKeyEmail(this, data[0], data[1],
+							data[2]);
+			getPreyConfig().saveAccount(accountData);
+		} catch (PreyException e) {
+			error = e.getMessage();
+		}
+		Intent resultIntent = new Intent(WelcomeBatchActivity.KEYBATCHRECEIVER_FILTER);
+		resultIntent.putExtra("error", error);
+		sendBroadcast(resultIntent);
+		return;
+	}
+
+	private PreyConfig getPreyConfig() {
+		return PreyConfig.getPreyConfig(this);
+	}
+}

--- a/src/com/prey/services/CheckPasswordService.java
+++ b/src/com/prey/services/CheckPasswordService.java
@@ -1,0 +1,37 @@
+package com.prey.services;
+
+import android.app.IntentService;
+import android.content.Intent;
+
+import com.prey.PreyConfig;
+import com.prey.activities.PasswordActivity;
+import com.prey.exceptions.PreyException;
+import com.prey.net.PreyWebServices;
+
+public class CheckPasswordService extends IntentService {
+	boolean isPasswordOk;
+	String error;
+
+	public CheckPasswordService(String name) {
+		super(name);
+	}
+
+	public void onHandleIntent(Intent intent) {
+		String[] password = intent.getStringArrayExtra("params");
+		try {
+			String email = getPreyConfig().getEmail();
+			isPasswordOk = PreyWebServices.getInstance().checkPassword(this, email, password[0]);
+		} catch (PreyException e) {
+			error = e.getMessage();
+		}
+		Intent resultIntent = new Intent(PasswordActivity.CHECKPWD_FILTER);
+		resultIntent.putExtra("error", error);
+		resultIntent.putExtra("isPasswordOk", isPasswordOk);
+		sendBroadcast(resultIntent);
+		return;
+	}
+
+	private PreyConfig getPreyConfig() {
+		return PreyConfig.getPreyConfig(this);
+	}
+}

--- a/src/com/prey/services/CreateAccountService.java
+++ b/src/com/prey/services/CreateAccountService.java
@@ -1,0 +1,44 @@
+package com.prey.services;
+
+import android.app.IntentService;
+import android.content.Intent;
+
+import com.prey.PreyAccountData;
+import com.prey.PreyConfig;
+import com.prey.PreyLogger;
+import com.prey.PreyUtils;
+import com.prey.activities.CreateAccountActivity;
+import com.prey.exceptions.PreyException;
+import com.prey.net.PreyWebServices;
+
+public class CreateAccountService extends IntentService {
+	String error;
+
+	public CreateAccountService(String name) {
+		super(name);
+	}
+
+	public void onHandleIntent(Intent intent) {
+		String[] data = intent.getStringArrayExtra("params");
+		try {
+			PreyAccountData accountData = PreyWebServices.getInstance()
+					.registerNewAccount(this, data[0], data[1], data[2], getDeviceType());
+			PreyLogger.d("Response creating account: " + accountData.toString());
+			getPreyConfig().saveAccount(accountData);
+		} catch (PreyException e) {
+			error = e.getMessage();
+		}
+		Intent resultIntent = new Intent(CreateAccountActivity.CREATEACCOUNT_FILTER);
+		resultIntent.putExtra("error", error);
+		sendBroadcast(resultIntent);
+		return;
+	}
+
+	private String getDeviceType() {
+		return PreyUtils.getDeviceType(this);
+	}
+
+	private PreyConfig getPreyConfig() {
+		return PreyConfig.getPreyConfig(this);
+	}
+}

--- a/src/com/prey/services/DetachDeviceService.java
+++ b/src/com/prey/services/DetachDeviceService.java
@@ -1,0 +1,33 @@
+package com.prey.services;
+
+import android.app.IntentService;
+import android.content.Intent;
+
+import com.prey.PreyConfig;
+import com.prey.exceptions.PreyException;
+import com.prey.net.PreyWebServices;
+import com.prey.preferences.DetachDevicePreferences;
+
+public class DetachDeviceService extends IntentService {
+	private String error;
+
+	public DetachDeviceService(String name) {
+		super(name);
+	}
+
+	public void onHandleIntent(Intent intent) {
+		try {
+			PreyConfig.getPreyConfig(this).unregisterC2dm(false);
+			PreyConfig.getPreyConfig(this).setSecurityPrivilegesAlreadyPrompted(false);
+			PreyWebServices.getInstance().deleteDevice(this);
+			PreyConfig.getPreyConfig(this).wipeData();
+		} catch (PreyException e) {
+			e.printStackTrace();
+			error = e.getMessage();
+		}
+		Intent resultIntent = new Intent(DetachDevicePreferences.DETACHDEVICE_FILTER);
+		resultIntent.putExtra("error", error);
+		sendBroadcast(resultIntent);
+		return;
+	}
+}

--- a/src/com/prey/services/RevokedPasswordPhraseService.java
+++ b/src/com/prey/services/RevokedPasswordPhraseService.java
@@ -1,0 +1,30 @@
+package com.prey.services;
+
+import android.app.IntentService;
+import android.content.Intent;
+
+import com.prey.PreyConfig;
+import com.prey.PreyLogger;
+import com.prey.preferences.RevokedPasswordPreferences;
+
+public class RevokedPasswordPhraseService extends IntentService {
+	String error;
+
+	public RevokedPasswordPhraseService(String name) {
+		super(name);
+	}
+
+	public void onHandleIntent(Intent intent) {
+		String data = intent.getStringExtra("param");
+		try {
+			PreyConfig preyConfig = PreyConfig.getPreyConfig(this);
+			PreyLogger.d("password [" + data + "]");
+			preyConfig.setRevokedPassword(true, data);
+		} catch (Exception e) {
+			error = e.getMessage();
+		}
+		Intent resultIntent = new Intent(RevokedPasswordPreferences.REVOKEDPWD_FILTER);
+		resultIntent.putExtra("error", error);
+		sendBroadcast(resultIntent);
+	}
+}


### PR DESCRIPTION
Hi prey-android-client developers, I'm doing research on Android async programming, particularly on 
AsyncTask and IntentService. AsyncTask can lead to memory leak and losing task result when GUI is recreated during task running (such as orientation change). [This article](http://bon-app-etit.blogspot.com/2013/04/the-dark-side-of-asynctask.html) describe the problems very well. 

We discussed with some Android experts and they agree with this issue, and claim that AsyncTask can be considered only for short tasks (less than 1 second). However, using IntentService (or AsyncTaskLoader) can avoid such problems since their lifecycles are independent from `Activity`.

In `prey-android-client`, most of the AsyncTasks are declared as inner classes of Activity/Preference. So the above issue can occur (especially for relatively long tasks).

I refactored 7 AsyncTasks in `prey-android-client` to IntentService (in 7 commits), with the help of a refactoring tool we developed. Do you think using IntentService should be better in these 7 scenario? Do you want to merge this pr? Thanks.