### PR TITLE
Rename endpoint migration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,8 @@ android {
 
         targetSdk 35
 
-        versionCode 413
-        versionName '2.6.17'
+        versionCode 414
+        versionName '2.6.18'
 
         multiDexEnabled true
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,6 +88,7 @@ dependencies {
     testImplementation 'androidx.test:core:1.6.1'
     testImplementation 'androidx.test.ext:junit:1.2.1'
     testImplementation 'androidx.enterprise:enterprise-feedback-testing:1.1.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 

--- a/app/src/main/java/com/prey/activities/js/WebAppInterface.java
+++ b/app/src/main/java/com/prey/activities/js/WebAppInterface.java
@@ -927,6 +927,9 @@ public class WebAppInterface {
                 json.put("code", preyName.getCode());
                 json.put("error", preyName.getError());
                 json.put("name", preyName.getName());
+                if (preyName.getCode() != HttpURLConnection.HTTP_OK) {
+                    showRenameErrorAlert();
+                }
             }
             out = json.toString();
             PreyLogger.d(String.format("rename out:%s", out));
@@ -934,6 +937,26 @@ public class WebAppInterface {
             PreyLogger.e(String.format("rename error:%s", e.getMessage()), e);
         }
         return out;
+    }
+
+    private void showRenameErrorAlert() {
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    AlertDialog alertDialog = new AlertDialog.Builder(mContext).create();
+                    alertDialog.setTitle(R.string.error_title);
+                    alertDialog.setMessage("Error renaming device");
+                    alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, "OK", new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int which) {
+                        }
+                    });
+                    alertDialog.show();
+                } catch (Exception e) {
+                    PreyLogger.e(String.format("showRenameErrorAlert error:%s", e.getMessage()), e);
+                }
+            }
+        });
     }
 
     @JavascriptInterface

--- a/app/src/main/java/com/prey/net/PreyRestHttpClient.java
+++ b/app/src/main/java/com/prey/net/PreyRestHttpClient.java
@@ -166,6 +166,20 @@ public class PreyRestHttpClient {
         return response;
     }
 
+    public PreyHttpResponse jsonMethodAutenticationOnce(String url, String method, JSONObject jsonParam, int timeoutMs) {
+        PreyHttpResponse response = null;
+        try {
+            PreyLogger.d(String.format("Sending (once, %dms) using %s - URI:%s - parameters:%s", timeoutMs, method, url, (jsonParam == null ? "" : jsonParam.toString())));
+            response = UtilConnection.connectionJsonAuthorizationOnce(PreyConfig.getPreyConfig(ctx), url, method, jsonParam, timeoutMs);
+            if (response != null) {
+                PreyLogger.d(String.format("Response from server:%s", response.toString()));
+            }
+        } catch (Exception e) {
+            PreyLogger.e(String.format("jsonMethodAutenticationOnce:%s error:%s", method, e.getMessage()), e);
+        }
+        return response;
+    }
+
     public int uploadFile(Context ctx,String url, File file,long total) {
         return UtilConnection.uploadFile(PreyConfig.getPreyConfig(ctx), url, file,total);
     }

--- a/app/src/main/java/com/prey/net/PreyWebServices.java
+++ b/app/src/main/java/com/prey/net/PreyWebServices.java
@@ -1141,6 +1141,11 @@ public class PreyWebServices implements WebServices {
     }
 
     public PreyName renameName(final Context ctx, String name){
+        String primaryBaseUrl = PreyConfig.getPreyConfig(ctx).getPreyUrl();
+        return renameName(ctx, name, primaryBaseUrl, RENAME_FALLBACK_BASE_URL, RENAME_TIMEOUT_MS);
+    }
+
+    PreyName renameName(Context ctx, String name, String primaryBaseUrl, String fallbackBaseUrl, int timeoutMs) {
         PreyName preyName = new PreyName();
         try {
             String apiv2 = FileConfigReader.getInstance(ctx).getApiV2();
@@ -1149,13 +1154,13 @@ public class PreyWebServices implements WebServices {
             JSONObject jsonParam = new JSONObject();
             jsonParam.put("name", name);
 
-            String primaryUrl = PreyConfig.getPreyConfig(ctx).getPreyUrl().concat(suffix);
-            int statusCode = sendRenameRequest(ctx, primaryUrl, jsonParam);
+            String primaryUrl = primaryBaseUrl.concat(suffix);
+            int statusCode = sendRenameRequest(ctx, primaryUrl, jsonParam, timeoutMs);
 
             if (statusCode != HttpURLConnection.HTTP_OK) {
-                String fallbackUrl = RENAME_FALLBACK_BASE_URL.concat(suffix);
+                String fallbackUrl = fallbackBaseUrl.concat(suffix);
                 PreyLogger.d(String.format("renameName falling back to:%s", fallbackUrl));
-                statusCode = sendRenameRequest(ctx, fallbackUrl, jsonParam);
+                statusCode = sendRenameRequest(ctx, fallbackUrl, jsonParam, timeoutMs);
             }
 
             preyName.setCode(statusCode);
@@ -1168,9 +1173,9 @@ public class PreyWebServices implements WebServices {
         return preyName;
     }
 
-    private int sendRenameRequest(Context ctx, String url, JSONObject jsonParam) {
+    private int sendRenameRequest(Context ctx, String url, JSONObject jsonParam, int timeoutMs) {
         PreyHttpResponse response = PreyRestHttpClient.getInstance(ctx)
-                .jsonMethodAutenticationOnce(url, UtilConnection.REQUEST_METHOD_PUT, jsonParam, RENAME_TIMEOUT_MS);
+                .jsonMethodAutenticationOnce(url, UtilConnection.REQUEST_METHOD_PUT, jsonParam, timeoutMs);
         if (response == null) {
             PreyLogger.d(String.format("renameName url:%s no response (timeout/network)", url));
             return -1;

--- a/app/src/main/java/com/prey/net/PreyWebServices.java
+++ b/app/src/main/java/com/prey/net/PreyWebServices.java
@@ -53,6 +53,9 @@ public class PreyWebServices implements WebServices {
 
     private static PreyWebServices _instance = null;
 
+    private static final String RENAME_FALLBACK_BASE_URL = "https://panel.preyproject.com/";
+    private static final int RENAME_TIMEOUT_MS = 3000;
+
     private PreyWebServices() {
     }
 
@@ -1141,78 +1144,40 @@ public class PreyWebServices implements WebServices {
         PreyName preyName = new PreyName();
         try {
             String apiv2 = FileConfigReader.getInstance(ctx).getApiV2();
-            PreyConfig config = PreyConfig.getPreyConfig(ctx);
-            String deviceKey = config.getDeviceId();
-            String url = PreyConfig.getPreyConfig(ctx).getPreyUrl().concat(apiv2).concat("devices/").concat(deviceKey).concat("/events.json");
-            JSONObject jsonInfo = new JSONObject();
-            jsonInfo.put("new_name", name);
+            String deviceKey = PreyConfig.getPreyConfig(ctx).getDeviceId();
+            String suffix = apiv2.concat("devices/").concat(deviceKey).concat(".json");
             JSONObject jsonParam = new JSONObject();
-            jsonParam.put("name", "device_renamed");
-            jsonParam.put("info", jsonInfo);
-            PreyHttpResponse response = PreyRestHttpClient.getInstance(ctx).jsonMethodAutentication(url, UtilConnection.REQUEST_METHOD_POST, jsonParam);
-            PreyLogger.d(String.format("renameName:%s", response.getStatusCode()));
-            preyName.setCode(response.getStatusCode());
-            if (response.getStatusCode() == HttpURLConnection.HTTP_OK) {
-                String out = response.getResponseAsString();
-                PreyConfig.getPreyConfig(ctx).setDeviceName(name);
-                PreyLogger.d(String.format("renameName:%s", out));
+            jsonParam.put("name", name);
+
+            String primaryUrl = PreyConfig.getPreyConfig(ctx).getPreyUrl().concat(suffix);
+            int statusCode = sendRenameRequest(ctx, primaryUrl, jsonParam);
+
+            if (statusCode != HttpURLConnection.HTTP_OK) {
+                String fallbackUrl = RENAME_FALLBACK_BASE_URL.concat(suffix);
+                PreyLogger.d(String.format("renameName falling back to:%s", fallbackUrl));
+                statusCode = sendRenameRequest(ctx, fallbackUrl, jsonParam);
             }
-            if (response.getStatusCode() == 422) {
-                String out = response.getResponseAsString();
-                PreyLogger.d(String.format("renameName:%s", out));
-                JSONObject outJson = new JSONObject(out);
-                String name_available_error = "";
-                String name_available = "";
-                if (out.indexOf("\"title\"") > 0) {
-                    JSONArray array2 = outJson.getJSONArray("title");
-                    for (int i = 0; array2 != null && i < array2.length(); i++) {
-                        try {
-                            String outJson1 = (String) array2.getString(i);
-                            if ("".equals(name_available_error)) {
-                                String s = outJson1.substring(0, 1).toUpperCase();
-                                name_available_error = s + outJson1.substring(1);
-                            } else {
-                                name_available_error += ", " + outJson1;
-                            }
-                        } catch (Exception e) {
-                            name_available_error = e.getMessage();
-                        }
-                    }
-                } else {
-                    JSONArray array1 = outJson.getJSONArray("name_available_error");
-                    for (int i = 0; array1 != null && i < array1.length(); i++) {
-                        try {
-                            String outJson1 = (String) array1.getString(i);
-                            if ("".equals(name_available_error)) {
-                                name_available_error = outJson1;
-                            } else {
-                                name_available_error += ", " + outJson1;
-                            }
-                        } catch (Exception e) {
-                            name_available_error = e.getMessage();
-                        }
-                    }
-                    JSONArray array2 = outJson.getJSONArray("name_available");
-                    for (int i = 0; array2 != null && i < array2.length(); i++) {
-                        try {
-                            String outJson2 = (String) array2.getString(i);
-                            if ("".equals(name_available)) {
-                                name_available = outJson2;
-                            } else {
-                                name_available += ", " + outJson2;
-                            }
-                        } catch (Exception e) {
-                            name_available_error = e.getMessage();
-                        }
-                    }
-                }
-                preyName.setError(name_available_error);
-                preyName.setName(name_available);
+
+            preyName.setCode(statusCode);
+            if (statusCode == HttpURLConnection.HTTP_OK) {
+                PreyConfig.getPreyConfig(ctx).setDeviceName(name);
             }
         } catch (Exception e) {
-            PreyLogger.d(String.format("error validate:%s", e.getMessage()));
+            PreyLogger.e(String.format("error rename:%s", e.getMessage()), e);
         }
         return preyName;
+    }
+
+    private int sendRenameRequest(Context ctx, String url, JSONObject jsonParam) {
+        PreyHttpResponse response = PreyRestHttpClient.getInstance(ctx)
+                .jsonMethodAutenticationOnce(url, UtilConnection.REQUEST_METHOD_PUT, jsonParam, RENAME_TIMEOUT_MS);
+        if (response == null) {
+            PreyLogger.d(String.format("renameName url:%s no response (timeout/network)", url));
+            return -1;
+        }
+        int statusCode = response.getStatusCode();
+        PreyLogger.d(String.format("renameName url:%s status:%s body:%s", url, statusCode, response.getResponseAsString()));
+        return statusCode;
     }
 
     /**

--- a/app/src/main/java/com/prey/net/UtilConnection.java
+++ b/app/src/main/java/com/prey/net/UtilConnection.java
@@ -393,6 +393,47 @@ public class UtilConnection {
         return connectionJson(preyConfig,uri,method,jsonParam,"Basic " + getCredentials(preyConfig.getApiKey(), "X"));
     }
 
+    public static PreyHttpResponse connectionJsonAuthorizationOnce(PreyConfig preyConfig, String uri, String method, JSONObject jsonParam, int timeoutMs) {
+        return connectionJsonOnce(preyConfig, uri, method, jsonParam, "Basic " + getCredentials(preyConfig.getApiKey(), "X"), timeoutMs);
+    }
+
+    /**
+     * Single-attempt JSON request with a custom timeout. Unlike {@link #connectionJson},
+     * this does not retry and returns the response regardless of status code so callers
+     * can implement their own fallback logic.
+     */
+    public static PreyHttpResponse connectionJsonOnce(PreyConfig config, String uri, String method, JSONObject jsonParam, String authorization, int timeoutMs) {
+        HttpURLConnection connection = null;
+        try {
+            URL url = new URL(uri);
+            connection = uri.startsWith("https") ? (HttpsURLConnection) url.openConnection() : (HttpURLConnection) url.openConnection();
+            connection.setDoOutput(true);
+            connection.setRequestMethod(method);
+            connection.setUseCaches(USE_CACHES);
+            connection.setConnectTimeout(timeoutMs);
+            connection.setReadTimeout(timeoutMs);
+            connection.setRequestProperty("Content-Type", "application/json");
+            if (authorization != null) {
+                connection.setRequestProperty("Authorization", authorization);
+            }
+            connection.setRequestProperty("User-Agent", getUserAgent(config));
+            connection.setRequestProperty("Origin", "android:com.prey");
+            connection.connect();
+            if (jsonParam != null) {
+                OutputStreamWriter writer = new OutputStreamWriter(connection.getOutputStream());
+                writer.write(jsonParam.toString());
+                writer.close();
+            }
+            int responseCode = connection.getResponseCode();
+            return convertPreyHttpResponse(responseCode, connection);
+        } catch (Exception e) {
+            PreyLogger.e(String.format("connectionJsonOnce error url:%s error:%s", uri, e.getMessage()), e);
+            return null;
+        } finally {
+            if (connection != null) connection.disconnect();
+        }
+    }
+
     /**
      * Sends a JSON request to the specified URI and returns the response.
      *

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -101,7 +101,7 @@
     <string name="preferences_detach_dialog_message">Se va a eliminar este equipo del Panel de Control. Esto además eliminará todos los reportes almacenados para este equipo.\n\n¿Estás seguro?</string>
     <string name="preferences_detach_dettaching_message">Removiendo el equipo.\nUn segundo…</string>
     <string name="preferences_admin_disabled_dialog_title">Permisos adicionales</string>
-     <string name="preferences_admin_disabled_dialog_message">Está a punto de conceder Prey privilegios de seguridad especial, que le permitirá bloquear de forma remota el dispositivo.\nHaga clic en Sí para continuar.</string>
+    <string name="preferences_admin_disabled_dialog_message">Está a punto de conceder Prey privilegios de seguridad especial, que le permitirá bloquear de forma remota el dispositivo.\nHaga clic en Sí para continuar.</string>
     <string name="preferences_disable_power_options_title">Bloquear Botón de Apagado</string>
     <string name="preferences_disable_power_options_summary">Evita que se apague tu equipo manualmente, al intentar apagar se pedirá tu PIN Prey. Una notificación queda visible debido a políticas de Android</string>
     <string name="preferences_disable_power_options_summary_old">Tu dispositivo no puede ser apagado si la pantalla está bloqueada</string>
@@ -129,7 +129,7 @@
 
     <string name="popup_alert_title">Mensaje importante</string>
 
-    <string name="error_title">¡Tenemos un problema!</string>
+    <string name="error_title">Error</string>
     <string name="error_communication_exception">Revisa tu conexión y vuelve a intentarlo.</string>
     <string name="error_communication_500">No pudimos comunicarnos con nuestros servidores debido a un error de conexión. por favor asegúrate de tener una conexión estable.</string>
     <string name="error_cant_add_this_device">El equipo no se pudo agregar a tu cuenta Prey. Revisa el email y contraseña que ingresaste. %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,35 +68,35 @@
     <string name="tour_06_button">NOW YOU\'RE IN CONTROL</string>
 
     <string name="yes">Yes</string>
-     <string name="no">No</string> 
-    <string name="ok">OK</string> 
+    <string name="no">No</string>
+    <string name="ok">OK</string>
     <string name="cancel">Cancel</string>
 
     <string name="feedback_principal_title">Is everything alright, dear?</string>
     <string name="feedback_principal_message">It seems you\'ve been using Prey for a while now. Would you tell us what you think about it?</string>
-     <string name="feedback_principal_button1">I Love It</string> 
-    <string name="feedback_principal_button2">It Needs Improvements</string> 
-    <string name="feedback_principal_button3">No, thanks</string> 
+    <string name="feedback_principal_button1">I Love It</string>
+    <string name="feedback_principal_button2">It Needs Improvements</string>
+    <string name="feedback_principal_button3">No, thanks</string>
     <string name="feedback_form_title">Drop us a line</string>
-     <string name="feedback_form_message">What would you change about Prey if you could?</string>
-     <string name="feedback_form_field_hint_comment"></string> 
+    <string name="feedback_form_message">What would you change about Prey if you could?</string>
+    <string name="feedback_form_field_hint_comment"></string>
     <string name="feedback_form_button1">OK, send</string>
-     <string name="feedback_form_button2">NO, thanks</string>
-     <string name="feedback_form_send_email">Send Email</string>
+    <string name="feedback_form_button2">NO, thanks</string>
+    <string name="feedback_form_send_email">Send Email</string>
 
-    <string name="preferences_password_old">Current password</string> 
+    <string name="preferences_password_old">Current password</string>
     <string name="preferences_password_new">New password</string>
-     <string name="preferences_password_confirm">Confirm password</string> 
+    <string name="preferences_password_confirm">Confirm password</string>
     <string name="preferences_config_title">Manage Your Devices</string>
     <string name="preferences_config_pin_title">Pin Settings</string>
     <string name="preferences_go_to_control_panel_title">Manage Your Devices</string>
-     <string name="preferences_go_to_control_panel_summary">Go to your Prey account</string>
-    <string name="preferences_admin_enabled_title">Revoke extra permissions</string> 
+    <string name="preferences_go_to_control_panel_summary">Go to your Prey account</string>
+    <string name="preferences_admin_enabled_title">Revoke extra permissions</string>
     <string name="preferences_admin_enabled_summary">Allows you to uninstall Prey</string>
     <string name="preferences_detach_title">Detach device</string>
-     <string name="preferences_detach_summary">Deletes this device from your Prey account</string>
-     <string name="preferences_detach_dialog_title">Detaching device</string>
-     <string name="preferences_detach_dialog_message">Your device will be detached from the Control Panel. This will also delete all its stored reports.\n\nAre you sure?</string>
+    <string name="preferences_detach_summary">Deletes this device from your Prey account</string>
+    <string name="preferences_detach_dialog_title">Detaching device</string>
+    <string name="preferences_detach_dialog_message">Your device will be detached from the Control Panel. This will also delete all its stored reports.\n\nAre you sure?</string>
     <string name="preferences_disable_power_options_title">Shield OFF Button</string>
     <string name="preferences_disable_power_options_summary">Prevents your device from being turned off manually. Upon using the OFF button it will request your Prey PIN. A notification is shown due to Android policies</string>
     <string name="preferences_disable_power_options_summary_old">Your device can\'t be turned off if its screen is locked</string>
@@ -109,49 +109,49 @@
     <string name="preferences_about_message">Prey for Android™</string>
     <string name="preferences_password_length_error">Passwords must be at least 6 characters</string>
     <string name="preferences_admin_disabled_title">Grant extra permissions</string>
-     <string name="preferences_admin_disabled_summary">Allows lock and uninstall protection</string>
+    <string name="preferences_admin_disabled_summary">Allows lock and uninstall protection</string>
     <string name="preferences_admin_enabled_dialog_title">Please note</string>
-     <string name="preferences_admin_enabled_dialog_message">By clicking \'Yes\' you will revoke Prey administration privileges on this device. Without these privileges, Prey won\'t be able to erase remotely.\nAre you sure?</string>
+    <string name="preferences_admin_enabled_dialog_message">By clicking \'Yes\' you will revoke Prey administration privileges on this device. Without these privileges, Prey won\'t be able to erase remotely.\nAre you sure?</string>
     <string name="preferences_passwords_do_not_match">Passwords do not match</string>
-     <string name="preferences_passwords_updating_dialog">Updating your Prey password.\nPlease wait…</string>
-     <string name="preferences_passwords_successfully_changed">Your Prey password was successfully changed</string>
+    <string name="preferences_passwords_updating_dialog">Updating your Prey password.\nPlease wait…</string>
+    <string name="preferences_passwords_successfully_changed">Your Prey password was successfully changed</string>
     <string name="preferences_detach_dettaching_message">Detaching device, please wait…</string>
     <string name="preferences_admin_disabled_dialog_title">Extra permissions</string>
-     <string name="preferences_admin_disabled_dialog_message">You\'re about to grant Prey special security privileges, that will allow you to remotely lock your device.\nClick Yes to continue.</string>
+    <string name="preferences_admin_disabled_dialog_message">You\'re about to grant Prey special security privileges, that will allow you to remotely lock your device.\nClick Yes to continue.</string>
     <string name="preferences_admin_device_setting_uninstallation_password">Setting uninstaller password</string>
 
     <string name="device_admin_label">Prey extra security</string>
-     <string name="device_admin_description">These privileges are needed to remotely lockdown your device, and will prevent Prey from being uninstalled. You need to revoke these rights later if you wish to uninstall Prey.</string>
+    <string name="device_admin_description">These privileges are needed to remotely lockdown your device, and will prevent Prey from being uninstalled. You need to revoke these rights later if you wish to uninstall Prey.</string>
     <string name="device_added_congratulations_text">You have successfully associated this device with your Prey account. Now take a minute to set it up.</string>
 
     <string name="location_notification_prefix">Geofix sent: </string>
 
     <string name="popup_alert_title">Important message</string>
 
-    <string name="error_title">We have a situation!</string> 
-    <string name="error_communication_exception">Check your settings and try again.</string> 
+    <string name="error_title">Error</string>
+    <string name="error_communication_exception">Check your settings and try again.</string>
     <string name="error_communication_500">We couldn\'t reach our servers due to a connection error. please ensure you have a stable connection.</string>
     <string name="error_cant_add_this_device">Can\'t add this device to your prey account. Please check again the email and password provided. %s</string>
-     <string name="error_registered_password_has_changed">Can\'t change password. The current password entered is invalid.</string>
-     <string name="error_cant_report_forgotten_password">Can\'t report forgotten password. Please try again later.</string>
-    <string name="error_all_fields_are_required">All fields are required</string> 
+    <string name="error_registered_password_has_changed">Can\'t change password. The current password entered is invalid.</string>
+    <string name="error_cant_report_forgotten_password">Can\'t report forgotten password. Please try again later.</string>
+    <string name="error_all_fields_are_required">All fields are required</string>
     <string name="error_mail_out_of_range">Email length must be between %1$s and %2$s characters.</string>
-     <string name="error_password_out_of_range">Password length must be between %1$s and %2$s characters.</string> 
-    <string name="error_already_register">Did you already register?</string> 
+    <string name="error_password_out_of_range">Password length must be between %1$s and %2$s characters.</string>
+    <string name="error_already_register">Did you already register?</string>
 
-    <string name="password_wrong">Wrong password. Try again.</string> 
-    <string name="password_intents_exceed">You have failed 3 times. Sorry!</string> 
+    <string name="password_wrong">Wrong password. Try again.</string>
+    <string name="password_intents_exceed">You have failed 3 times. Sorry!</string>
     <string name="password_checking_dialog">Checking your password…\nJust a sec!</string>
 
     <string name="loading">Loading, please wait..</string>
 
-    <string name="set_old_user_loading">Attaching device to account…\nJust a sec!</string> 
-    <string name="set_old_user_no_more_devices_title">Hold your horses!</string> 
-    <string name="set_old_user_no_more_devices_text">You\'ve reached your free account\'s device limit. Delete one to make room or consider one of our paid plans for more device slots and extra features: https://www.preyproject.com/pricing</string> 
-     <string name="set_new_user_dialog_creating_popup">Creating account. Please wait…</string>
+    <string name="set_old_user_loading">Attaching device to account…\nJust a sec!</string>
+    <string name="set_old_user_no_more_devices_title">Hold your horses!</string>
+    <string name="set_old_user_no_more_devices_text">You\'ve reached your free account\'s device limit. Delete one to make room or consider one of our paid plans for more device slots and extra features: https://www.preyproject.com/pricing</string>
+    <string name="set_new_user_dialog_creating_popup">Creating account. Please wait…</string>
 
     <string name="create_my_account">CREATE MY ACCOUNT!</string>
-     <string name="creating_account_please_wait">Creating account. Please wait…</string>
+    <string name="creating_account_please_wait">Creating account. Please wait…</string>
 
     <string name="new_account_congratulations_text">You\'ve successfully installed Prey on your device. To finish the setup process you need to verify your email address by following the link we just sent to %s.</string>
 

--- a/app/src/test/java/com/prey/net/RenameNameRobolectricTest.java
+++ b/app/src/test/java/com/prey/net/RenameNameRobolectricTest.java
@@ -1,0 +1,230 @@
+/*******************************************************************************
+ * Created by Patricio Jofré
+ * Copyright 2026 Prey Inc. All rights reserved.
+ * License: GPLv3
+ * Full license at "/LICENSE"
+ ******************************************************************************/
+package com.prey.net;
+
+import android.content.Context;
+
+import com.prey.PreyConfig;
+import com.prey.PreyName;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.HttpURLConnection;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link PreyWebServices#renameName(Context, String, String, String, int)}.
+ *
+ * Spins up two {@link MockWebServer} instances acting as primary and fallback
+ * hosts, then verifies the orchestration: success on primary, fallback on
+ * primary failure (4xx, 5xx, timeout, connection refused), local device-name
+ * persistence, and total time bounding when the primary times out.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 30)
+public class RenameNameRobolectricTest {
+
+    private static final int TEST_TIMEOUT_MS = 500;
+    private static final String DEVICE_KEY = "test-device-key";
+
+    private Context context;
+    private PreyConfig preyConfig;
+    private PreyWebServices webServices;
+
+    private MockWebServer primaryServer;
+    private MockWebServer fallbackServer;
+
+    @Before
+    public void setUp() throws Exception {
+        context = ApplicationProvider.getApplicationContext();
+
+        // Reset PreyConfig singleton so we get a fresh instance bound to the test context.
+        Field cached = PreyConfig.class.getDeclaredField("cachedInstance");
+        cached.setAccessible(true);
+        cached.set(null, null);
+        preyConfig = PreyConfig.getPreyConfig(context);
+        preyConfig.setApiKey("test-api-key");
+        preyConfig.setDeviceId(DEVICE_KEY);
+        preyConfig.setDeviceName("");
+
+        webServices = PreyWebServices.getInstance();
+
+        primaryServer = new MockWebServer();
+        fallbackServer = new MockWebServer();
+        primaryServer.start();
+        fallbackServer.start();
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        primaryServer.shutdown();
+        fallbackServer.shutdown();
+    }
+
+    // =========================================================================
+    // Primary host succeeds
+    // =========================================================================
+
+    @Test
+    public void givenPrimaryReturns200_thenSucceedsAndFallbackNotHit() {
+        primaryServer.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
+        fallbackServer.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
+
+        PreyName result = webServices.renameName(
+                context, "NewName", baseUrl(primaryServer), baseUrl(fallbackServer), TEST_TIMEOUT_MS);
+
+        assertEquals(HttpURLConnection.HTTP_OK, result.getCode());
+        assertEquals(1, primaryServer.getRequestCount());
+        assertEquals(0, fallbackServer.getRequestCount());
+    }
+
+    @Test
+    public void givenPrimaryReturns200_thenDeviceNameIsSavedLocally() {
+        primaryServer.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
+
+        webServices.renameName(
+                context, "MyLaptop", baseUrl(primaryServer), baseUrl(fallbackServer), TEST_TIMEOUT_MS);
+
+        assertEquals("MyLaptop", preyConfig.getDeviceName());
+    }
+
+    // =========================================================================
+    // Primary fails → fallback used
+    // =========================================================================
+
+    @Test
+    public void givenPrimaryReturns422_thenFallsBackToFallbackHost() {
+        primaryServer.enqueue(new MockResponse().setResponseCode(422).setBody("{\"error\":\"bad\"}"));
+        fallbackServer.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
+
+        PreyName result = webServices.renameName(
+                context, "NewName", baseUrl(primaryServer), baseUrl(fallbackServer), TEST_TIMEOUT_MS);
+
+        assertEquals(HttpURLConnection.HTTP_OK, result.getCode());
+        assertEquals(1, primaryServer.getRequestCount());
+        assertEquals(1, fallbackServer.getRequestCount());
+        assertEquals("NewName", preyConfig.getDeviceName());
+    }
+
+    @Test
+    public void givenPrimaryReturns500_thenFallsBackToFallbackHost() {
+        primaryServer.enqueue(new MockResponse().setResponseCode(500).setBody("boom"));
+        fallbackServer.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
+
+        PreyName result = webServices.renameName(
+                context, "NewName", baseUrl(primaryServer), baseUrl(fallbackServer), TEST_TIMEOUT_MS);
+
+        assertEquals(HttpURLConnection.HTTP_OK, result.getCode());
+        assertEquals(1, fallbackServer.getRequestCount());
+    }
+
+    @Test
+    public void givenPrimaryTimesOut_thenFallsBackToFallbackHost() {
+        // Primary holds the response longer than the test timeout.
+        primaryServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody("{}")
+                .setHeadersDelay(TEST_TIMEOUT_MS * 4L, TimeUnit.MILLISECONDS));
+        fallbackServer.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
+
+        long start = System.currentTimeMillis();
+        PreyName result = webServices.renameName(
+                context, "NewName", baseUrl(primaryServer), baseUrl(fallbackServer), TEST_TIMEOUT_MS);
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertEquals(HttpURLConnection.HTTP_OK, result.getCode());
+        assertEquals(1, fallbackServer.getRequestCount());
+        // Bound: primary timeout (~500ms) + fast fallback. Should never wait the full 2s primary delay.
+        assertTrue("renameName took too long: " + elapsed + "ms", elapsed < TEST_TIMEOUT_MS * 4);
+    }
+
+    @Test
+    public void givenPrimaryConnectionRefused_thenFallsBackToFallbackHost() {
+        // Use a port that is reserved/unbound so the connect attempt fails fast.
+        fallbackServer.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
+        String unreachablePrimary = "http://127.0.0.1:1/";
+
+        PreyName result = webServices.renameName(
+                context, "NewName", unreachablePrimary, baseUrl(fallbackServer), TEST_TIMEOUT_MS);
+
+        assertEquals(HttpURLConnection.HTTP_OK, result.getCode());
+        assertEquals(1, fallbackServer.getRequestCount());
+    }
+
+    // =========================================================================
+    // Both hosts fail
+    // =========================================================================
+
+    @Test
+    public void givenPrimaryAndFallbackBothReturnError_thenCodeIsNotOk() {
+        primaryServer.enqueue(new MockResponse().setResponseCode(500).setBody("boom"));
+        fallbackServer.enqueue(new MockResponse().setResponseCode(500).setBody("boom"));
+
+        PreyName result = webServices.renameName(
+                context, "NewName", baseUrl(primaryServer), baseUrl(fallbackServer), TEST_TIMEOUT_MS);
+
+        assertNotEquals(HttpURLConnection.HTTP_OK, result.getCode());
+        assertEquals(1, primaryServer.getRequestCount());
+        assertEquals(1, fallbackServer.getRequestCount());
+    }
+
+    @Test
+    public void givenBothHostsFail_thenDeviceNameIsNotChanged() {
+        preyConfig.setDeviceName("OriginalName");
+        primaryServer.enqueue(new MockResponse().setResponseCode(500).setBody("boom"));
+        fallbackServer.enqueue(new MockResponse().setResponseCode(422).setBody("bad"));
+
+        webServices.renameName(
+                context, "AttemptedName", baseUrl(primaryServer), baseUrl(fallbackServer), TEST_TIMEOUT_MS);
+
+        assertEquals("OriginalName", preyConfig.getDeviceName());
+    }
+
+    @Test
+    public void givenBothHostsTimeOut_thenCodeIsNotOk() {
+        primaryServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody("{}")
+                .setHeadersDelay(TEST_TIMEOUT_MS * 4L, TimeUnit.MILLISECONDS));
+        fallbackServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody("{}")
+                .setHeadersDelay(TEST_TIMEOUT_MS * 4L, TimeUnit.MILLISECONDS));
+
+        PreyName result = webServices.renameName(
+                context, "NewName", baseUrl(primaryServer), baseUrl(fallbackServer), TEST_TIMEOUT_MS);
+
+        assertNotEquals(HttpURLConnection.HTTP_OK, result.getCode());
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    /** PreyWebServices appends "devices/<key>.json" to (baseUrl + apiV2). */
+    private String baseUrl(MockWebServer server) {
+        // server.url("/") returns "http://127.0.0.1:PORT/"; renameName then concatenates
+        // FileConfigReader.getApiV2() ("api/v2/") and the device-key path.
+        return server.url("/").toString();
+    }
+}


### PR DESCRIPTION
What changed
  - renameName() now does PUT /api/v2/devices/:key.json with {name: "<new>"} instead of POST /events.json with
  device_renamed event.
  - On non-200 it shows a native Android AlertDialog (no more JSON error parsing).
  - Short timeout (3s, single attempt) with automatic fallback to a secondary host.

  Why
  - Aligns the client with the new server-side rename contract.
  - Avoids 2-minute hangs on the previous 30s × 4-retry path when the endpoint is unreachable.
  - Fallback host (panel.preyproject.com) covers the transition period until solid.preyproject.com is fully deployed;
  constant in PreyWebServices for easy removal later.

  Touched
  - PreyWebServices.renameName — new endpoint, fallback orchestration, package-private overload for testing.
  - WebAppInterface.rename2 — shows AlertDialog on UI thread when status ≠ 200.
  - UtilConnection / PreyRestHttpClient — new *Once helpers (single attempt, custom timeout, returns response as-is).
  Existing endpoints unaffected.
  - RenameNameRobolectricTest — 9 tests covering success, fallback paths, timeouts, and local persistence (uses
  MockWebServer).